### PR TITLE
Add options to KinesisProducerConfiguration

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kinematics "0.2.0"
+(defproject kinematics "0.2.1-SNAPSHOT"
   :description "AWS Kinesis Consumer & Producer"
   :url "http://github.com/bpoweski/kinematics"
   :license {:name "Eclipse Public License"

--- a/src/kinematics/producer.clj
+++ b/src/kinematics/producer.clj
@@ -3,13 +3,16 @@
            [java.nio ByteBuffer]))
 
 
-(defn ^KinesisProducerConfiguration config [{:keys [credentials-provider region max-connections request-timeout record-max-buffered-time]}]
+(defn ^KinesisProducerConfiguration config [{:keys [credentials-provider region max-connections request-timeout record-max-buffered-time kinesis-endpoint kinesis-port set-verify-certificate]}]
   (cond-> (KinesisProducerConfiguration.)
     credentials-provider     (.setCredentialsProvider credentials-provider)
     region                   (.setRegion (name region))
     max-connections          (.setMaxConnections max-connections)
     request-timeout          (.setRequestTimeout request-timeout)
-    record-max-buffered-time (.setRecordMaxBufferedTime record-max-buffered-time)))
+    record-max-buffered-time (.setRecordMaxBufferedTime record-max-buffered-time)
+    kinesis-endpoint         (.setKinesisEndpoint kinesis-endpoint)
+    kinesis-port             (.setKinesisPort kinesis-port)
+    set-verify-certificate   (.setVerifyCertificate set-verify-certificate)))
 
 (defn create [opts]
   (KinesisProducer. (config opts)))


### PR DESCRIPTION
* Support options useful for local testing with Kinesalite
** https://github.com/mhart/kinesalite
* kinematics.producer/config supports three more options:
** kinesis-endpoint
** kinesis-port
** set-verify-certificate
* Update project version