### PR TITLE
[DEV-8425] Update snapshot version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kinematics "0.2.1-SNAPSHOT"
+(defproject kinematics "0.2.2-SNAPSHOT"
   :description "AWS Kinesis Consumer & Producer"
   :url "http://github.com/bpoweski/kinematics"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
[DEV-8425]

Well fuck, I didn't update the project version.
And our Price Sheet Docker file uses `lein deps` and `lein uberjar` which doesn't force snapshots to be updated.

@bpoweski Am I freaking out for nothing? Or is this correct. 
I expected not to see certain "detail" level cloud watch metrics like `UserRecordsPending`
which I still see. 
